### PR TITLE
Fix Kotlin plugin configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
+    // Use the official Kotlin Android plugin ID
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.4.2"
+        // Add Kotlin Gradle plugin for Kotlin Android support
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     }
 }
 


### PR DESCRIPTION
## Summary
- add Kotlin Gradle plugin classpath
- switch `kotlin-android` plugin to official ID

## Testing
- `gradle tasks` *(fails: Could not resolve com.android.tools.build:gradle:7.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_684952f84e4c8333a5b2de6cecc9d710