### PR TITLE
Address AndroidX and exported activity warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
+    // Use the official Kotlin Android plugin ID
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:allowBackup="true"
         android:label="Router Manager"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.4.2"
+        // Add Kotlin Gradle plugin for Kotlin Android support
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX support via `gradle.properties`
- mark `MainActivity` as exported per Android 12 requirements

## Testing
- `gradle tasks` *(fails: Could not resolve Gradle dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684952f84e4c8333a5b2de6cecc9d710