### PR TITLE
Fix Kotlin compile target

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,9 @@ android {
             minifyEnabled false
         }
     }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
     namespace 'com.example.routermanager'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
+android.defaults.buildfeatures.buildConfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
## Summary
- set Kotlin `jvmTarget` to `17`
- update deprecated `buildconfig` flag to `buildConfig`

## Testing
- `gradle help` *(fails: Could not resolve com.android.tools.build:gradle:8.10.1)*

------
https://chatgpt.com/codex/tasks/task_e_68495d18dda48333a2866a5a084b2776