### PR TITLE
Add namespace in Android block

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 android {
     compileSdk 34
+    namespace "com.example.routermanager"
 
     defaultConfig {
         applicationId "com.example.routermanager"


### PR DESCRIPTION
## Summary
- specify package namespace in `android` block

## Testing
- `gradle help --dry-run` *(fails: Could not resolve gradle dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68496efa31288333a77b5d78b507bddb