### PR TITLE
Add Espresso test for WebView URL

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,4 +36,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
@@ -1,0 +1,28 @@
+package com.example.routermanager
+
+import android.webkit.WebView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun webViewLoadsExpectedUrl() {
+        onView(withId(R.id.routerWebView)).check { view, noViewFoundException ->
+            if (noViewFoundException != null) throw noViewFoundException
+            val webView = view as WebView
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            assertEquals("http://10.80.80.1/", webView.url)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add instrumentation test for MainActivity
- add Espresso and junit dependencies

## Testing
- `./gradlew test` *(fails: unable to download Gradle distribution)*
- `./gradlew connectedAndroidTest` *(fails: unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6849755e24b88333a3814f1bf84ed60c