### PR TITLE
Handle SSL errors with custom WebViewClient

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -1,17 +1,35 @@
 package com.example.routermanager
 
 import android.os.Bundle
+import android.app.AlertDialog
+import android.webkit.SslErrorHandler
+import android.net.http.SslError
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+    private inner class RouterWebViewClient : WebViewClient() {
+        override fun onReceivedSslError(
+            view: WebView?,
+            handler: SslErrorHandler?,
+            error: SslError?
+        ) {
+            AlertDialog.Builder(this@MainActivity)
+                .setTitle("SSL Certificate Error")
+                .setMessage("The router presented an untrusted certificate. Continue anyway?")
+                .setPositiveButton("Continue") { _, _ -> handler?.proceed() }
+                .setNegativeButton("Cancel") { _, _ -> handler?.cancel() }
+                .setCancelable(false)
+                .show()
+        }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         val webView: WebView = findViewById(R.id.routerWebView)
-        webView.webViewClient = WebViewClient()
+        webView.webViewClient = RouterWebViewClient()
         webView.settings.javaScriptEnabled = true
         webView.loadUrl("http://10.80.80.1/")
     }


### PR DESCRIPTION
## Summary
- add a RouterWebViewClient that prompts the user when the router's SSL certificate is untrusted
- use this client in MainActivity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68497f1624a083339a31829eee81c6e1