### PR TITLE
Add progress indicator for WebView loading

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -6,10 +6,15 @@ import android.webkit.SslErrorHandler
 import android.net.http.SslError
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.graphics.Bitmap
+import android.view.View
+import android.widget.ProgressBar
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var progressBar: ProgressBar
+
     private inner class RouterWebViewClient : WebViewClient() {
         override fun onReceivedSslError(
             view: WebView?,
@@ -24,6 +29,16 @@ class MainActivity : AppCompatActivity() {
                 .setCancelable(false)
                 .show()
         }
+
+        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+            super.onPageStarted(view, url, favicon)
+            progressBar.visibility = View.VISIBLE
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            super.onPageFinished(view, url)
+            progressBar.visibility = View.GONE
+        }
     }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +46,7 @@ class MainActivity : AppCompatActivity() {
 
         val webView: WebView = findViewById(R.id.routerWebView)
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
+        progressBar = findViewById(R.id.loadingProgress)
         webView.webViewClient = RouterWebViewClient()
         webView.settings.javaScriptEnabled = true
         webView.loadUrl("https://10.80.80.1/")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <ProgressBar
+        android:id="@+id/loadingProgress"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        android:indeterminate="true" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/refreshButton"
         android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- display a `ProgressBar` overlay in `activity_main.xml`
- show and hide the progress indicator in `RouterWebViewClient`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68498379625883339ae57b5609f0a1cf