### PR TITLE
Align Router URL on HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RouterManager
 
-RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. By default, the app loads `http://10.80.80.1/`.
+RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. By default, the app loads `https://10.80.80.1/`.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 
 ## Launching the WebView App
 
-After installing the APK on your device, launch the **RouterManager** application. The WebView will automatically navigate to `http://10.80.80.1/`, allowing you to interact with the router's web interface.
+After installing the APK on your device, launch the **RouterManager** application. The WebView will automatically navigate to `https://10.80.80.1/`, allowing you to interact with the router's web interface.
 
 You may also open the project in Android Studio and run it directly from there using the built-in Gradle wrapper support.
 

--- a/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
@@ -22,7 +22,7 @@ class MainActivityTest {
             if (noViewFoundException != null) throw noViewFoundException
             val webView = view as WebView
             InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-            assertEquals("http://10.80.80.1/", webView.url)
+            assertEquals("https://10.80.80.1/", webView.url)
         }
     }
 }

--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -14,6 +14,8 @@ import android.widget.ProgressBar
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 
+private const val ROUTER_URL = "https://10.80.80.1/"
+
 class MainActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
 
@@ -66,7 +68,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
         webView.settings.javaScriptEnabled = true
-        webView.loadUrl("https://10.80.80.1/")
+        webView.loadUrl(ROUTER_URL)
         refreshButton.setOnClickListener { webView.reload() }
     }
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
+    <domain-config cleartextTrafficPermitted="false">
         <domain>10.80.80.1</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- add constant for router URL
- update README and instrumentation test to expect HTTPS
- block cleartext HTTP traffic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68498b583afc833388440a797b0e2fa5