### PR TITLE
Enable cleartext traffic and JS features

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -8,6 +8,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebChromeClient
 import android.webkit.JsResult
+import android.webkit.WebSettings
 import android.graphics.Bitmap
 import android.view.View
 import android.widget.ProgressBar
@@ -67,7 +68,11 @@ class MainActivity : AppCompatActivity() {
                 return true
             }
         }
-        webView.settings.javaScriptEnabled = true
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        }
         webView.loadUrl(ROUTER_URL)
         refreshButton.setOnClickListener { webView.reload() }
     }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false">
+    <domain-config cleartextTrafficPermitted="true">
         <domain>10.80.80.1</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- allow cleartext traffic for the router domain
- enable DOM storage and mixed content in the WebView

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68498e4d4f1483339cd3c97e142d5243