### PR TITLE
Allow HTTP subdomains

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
     <domain-config cleartextTrafficPermitted="true">
-        <domain>10.80.80.1</domain>
+        <domain includeSubdomains="true">10.80.80.1</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- allow all cleartext traffic in network security config
- include subdomains for the router

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684980de632883339e8b42fdb14104c8