### PR TITLE
Persist trusted SSL state

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -21,6 +21,7 @@ private const val ROUTER_URL = "https://10.80.80.1/"
 
 class MainActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
+    private var sslTrusted: Boolean = false
 
     private inner class RouterWebViewClient : WebViewClient() {
         override fun onReceivedSslError(
@@ -28,10 +29,18 @@ class MainActivity : AppCompatActivity() {
             handler: SslErrorHandler?,
             error: SslError?
         ) {
+            if (sslTrusted) {
+                handler?.proceed()
+                return
+            }
+
             AlertDialog.Builder(this@MainActivity)
                 .setTitle("SSL Certificate Error")
                 .setMessage("The router presented an untrusted certificate. Continue anyway?")
-                .setPositiveButton("Continue") { _, _ -> handler?.proceed() }
+                .setPositiveButton("Continue") { _, _ ->
+                    sslTrusted = true
+                    handler?.proceed()
+                }
                 .setNegativeButton("Cancel") { _, _ -> handler?.cancel() }
                 .setCancelable(false)
                 .show()


### PR DESCRIPTION
## Summary
- remember router SSL confirmation in `MainActivity`
- skip the warning dialog once a certificate is trusted

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684994c9ce648333b4e5ee07b4f33d8b