### PR TITLE
Implement JS confirm dialog

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -100,6 +100,20 @@ class MainActivity : AppCompatActivity() {
                     .show()
                 return true
             }
+            override fun onJsConfirm(
+                view: WebView?,
+                url: String?,
+                message: String?,
+                result: JsResult?,
+            ): Boolean {
+                AlertDialog.Builder(this@MainActivity)
+                    .setMessage(message)
+                    .setPositiveButton(android.R.string.ok) { _, _ -> result?.confirm() }
+                    .setNegativeButton(android.R.string.cancel) { _, _ -> result?.cancel() }
+                    .setCancelable(false)
+                    .show()
+                return true
+            }
         }
         webView.settings.apply {
             javaScriptEnabled = true


### PR DESCRIPTION
## Summary
- use Material AlertDialog to handle JS confirm dialogs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68499b93417c8333ae95d9dc49279978