### PR TITLE
Add SetupActivity for configurable router URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RouterManager
 
-RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. By default, the app loads `https://10.80.80.1/`.
+RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. The first time you launch the app you'll be asked to enter the router URL, which is then stored for future sessions. If no value is entered the app falls back to `https://10.80.80.1/`.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 
 ## Launching the WebView App
 
-After installing the APK on your device, launch the **RouterManager** application. The WebView will automatically navigate to `https://10.80.80.1/`, allowing you to interact with the router's web interface.
+After installing the APK on your device, launch the **RouterManager** application. You'll first be presented with a screen to enter your router's URL. Once saved, the WebView will automatically navigate to that address on subsequent launches (defaulting to `https://10.80.80.1/` if none is specified).
 
 You may also open the project in Android Studio and run it directly from there using the built-in Gradle wrapper support.
 

--- a/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
@@ -3,6 +3,7 @@ package com.example.routermanager
 import android.webkit.WebView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import android.content.Context
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
@@ -15,6 +16,13 @@ import org.junit.runner.RunWith
 class MainActivityTest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @org.junit.Before
+    fun setupPrefs() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+        prefs.edit().putString("routerUrl", "https://10.80.80.1/").commit()
+    }
 
     @Test
     fun webViewLoadsExpectedUrl() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,12 +13,13 @@
         android:theme="@style/Theme.RouterManager"
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="24">
-        <activity android:name=".MainActivity" android:exported="true">
+        <activity android:name=".SetupActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainActivity" android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -20,7 +20,8 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 
-private const val ROUTER_URL = "https://10.80.80.1/"
+private const val KEY_ROUTER_URL = "routerUrl"
+private const val DEFAULT_ROUTER_URL = "https://10.80.80.1/"
 private const val KEY_SSL_TRUSTED = "sslTrusted"
 
 class MainActivity : AppCompatActivity() {
@@ -81,6 +82,9 @@ class MainActivity : AppCompatActivity() {
         sharedPrefs = getPreferences(MODE_PRIVATE)
         sslTrusted = savedInstanceState?.getBoolean(KEY_SSL_TRUSTED)
             ?: sharedPrefs.getBoolean(KEY_SSL_TRUSTED, false)
+        val settings = getSharedPreferences("settings", MODE_PRIVATE)
+        val routerUrl = settings.getString(KEY_ROUTER_URL, DEFAULT_ROUTER_URL)
+            ?: DEFAULT_ROUTER_URL
         setContentView(R.layout.activity_main)
 
         val webView: WebView = findViewById(R.id.routerWebView)
@@ -129,7 +133,7 @@ class MainActivity : AppCompatActivity() {
             CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
         }
 
-        webView.loadUrl(ROUTER_URL)
+        webView.loadUrl(routerUrl)
 
         refreshButton.setOnClickListener {
             webView.url?.let { currentUrl -> webView.loadUrl(currentUrl) }
@@ -140,7 +144,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         homeButton.setOnClickListener {
-            webView.loadUrl(ROUTER_URL)
+            webView.loadUrl(routerUrl)
         }
     }
 

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -1,0 +1,30 @@
+package com.example.routermanager
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+private const val KEY_ROUTER_URL = "routerUrl"
+
+class SetupActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        if (prefs.contains(KEY_ROUTER_URL)) {
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+            return
+        }
+        setContentView(R.layout.activity_setup)
+        val urlField: EditText = findViewById(R.id.urlEditText)
+        val accessButton: Button = findViewById(R.id.accessButton)
+        accessButton.setOnClickListener {
+            val url = urlField.text.toString()
+            prefs.edit().putString(KEY_ROUTER_URL, url).apply()
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/urlEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Router URL" />
+
+    <Button
+        android:id="@+id/accessButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Access"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add SetupActivity to configure router URL on first launch
- load saved router URL in MainActivity
- update instrumentation test for new prefs
- update manifest and README

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849b460d6588333842ffb4a7e602dc1