### PR TITLE
Add Off FAB to reset config

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -16,7 +16,9 @@ import android.graphics.Bitmap
 import android.view.View
 import android.widget.ProgressBar
 import android.content.SharedPreferences
+import android.content.Intent
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 
@@ -91,6 +93,7 @@ class MainActivity : AppCompatActivity() {
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val speedTestButton: FloatingActionButton = findViewById(R.id.speedTestButton)
         val homeButton: FloatingActionButton = findViewById(R.id.homeButton)
+        val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
         progressBar = findViewById(R.id.loadingProgress)
         webView.webViewClient = RouterWebViewClient()
         webView.webChromeClient = object : WebChromeClient() {
@@ -145,6 +148,13 @@ class MainActivity : AppCompatActivity() {
 
         homeButton.setOnClickListener {
             webView.loadUrl(routerUrl)
+        }
+
+        offButton.setOnClickListener {
+            getSharedPreferences("settings", MODE_PRIVATE).edit().clear().apply()
+            sharedPrefs.edit().clear().apply()
+            startActivity(Intent(this, SetupActivity::class.java))
+            finish()
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -44,7 +44,14 @@
             android:id="@+id/speedTestButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
             app:srcCompat="@android:drawable/ic_menu_manage" />
+
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/offButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Off" />
 
     </LinearLayout>
 


### PR DESCRIPTION
## Summary
- add an extended FAB labelled Off in `activity_main.xml`
- handle new button in `MainActivity` to clear preferences and launch `SetupActivity`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849b6aa2b1c8333b6b7e85ebdb4d5e8