### PR TITLE
Add SpeedTestActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".MainActivity" android:exported="true" />
+        <activity android:name=".SpeedTestActivity" android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -143,7 +143,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         speedTestButton.setOnClickListener {
-            webView.loadUrl("https://unifi-my.speedtestcustom.com/")
+            startActivity(Intent(this, SpeedTestActivity::class.java))
         }
 
         homeButton.setOnClickListener {

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -1,0 +1,42 @@
+package com.example.routermanager
+
+import android.os.Bundle
+import android.webkit.WebView
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
+import android.webkit.WebSettings
+import android.webkit.CookieManager
+
+class SpeedTestActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_speed_test)
+
+        val webView: WebView = findViewById(R.id.speedTestWebView)
+        val backButton: Button = findViewById(R.id.backButton)
+        val refreshButton: Button = findViewById(R.id.refreshButton)
+        val offButton: Button = findViewById(R.id.offButton)
+
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        }
+        CookieManager.getInstance().setAcceptCookie(true)
+        webView.loadUrl("https://unifi-my.speedtestcustom.com/")
+
+        backButton.setOnClickListener {
+            finish()
+        }
+        refreshButton.setOnClickListener {
+            webView.url?.let { currentUrl -> webView.loadUrl(currentUrl) }
+        }
+        offButton.setOnClickListener {
+            getSharedPreferences("settings", MODE_PRIVATE).edit().clear().apply()
+            getPreferences(MODE_PRIVATE).edit().clear().apply()
+            startActivity(Intent(this, SetupActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <WebView
+        android:id="@+id/speedTestWebView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:padding="16dp">
+
+        <Button
+            android:id="@+id/backButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="Back" />
+
+        <Button
+            android:id="@+id/refreshButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="Refresh" />
+
+        <Button
+            android:id="@+id/offButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Off" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add `SpeedTestActivity` with a WebView and control buttons
- create matching `activity_speed_test.xml` layout
- register the new activity in the manifest
- launch `SpeedTestActivity` when pressing the Speed Test FAB

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download Gradle wrapper due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6849b7447dc48333b66f487a335f70be