### PR TITLE
Handle blank router URL in setup

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -21,8 +21,14 @@ class SetupActivity : AppCompatActivity() {
         val urlField: EditText = findViewById(R.id.urlEditText)
         val accessButton: Button = findViewById(R.id.accessButton)
         accessButton.setOnClickListener {
-            val url = urlField.text.toString()
-            prefs.edit().putString(KEY_ROUTER_URL, url).apply()
+            val url = urlField.text.toString().trim()
+            val editor = prefs.edit()
+            if (url.isBlank()) {
+                editor.remove(KEY_ROUTER_URL)
+            } else {
+                editor.putString(KEY_ROUTER_URL, url)
+            }
+            editor.apply()
             startActivity(Intent(this, MainActivity::class.java))
             finish()
         }


### PR DESCRIPTION
## Summary
- trim router URL text before saving
- skip saving when input is blank so `MainActivity` uses the default URL

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849bbc5236483338c7601c43605109a