### PR TITLE
Switch speed test controls to FABs

### DIFF
--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -2,7 +2,8 @@ package com.example.routermanager
 
 import android.os.Bundle
 import android.webkit.WebView
-import android.widget.Button
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 import android.content.Intent
 import android.webkit.WebSettings
@@ -14,9 +15,9 @@ class SpeedTestActivity : AppCompatActivity() {
         setContentView(R.layout.activity_speed_test)
 
         val webView: WebView = findViewById(R.id.speedTestWebView)
-        val backButton: Button = findViewById(R.id.backButton)
-        val refreshButton: Button = findViewById(R.id.refreshButton)
-        val offButton: Button = findViewById(R.id.offButton)
+        val backButton: FloatingActionButton = findViewById(R.id.backButton)
+        val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
+        val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
 
         webView.settings.apply {
             javaScriptEnabled = true

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -23,21 +23,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <Button
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/backButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
-            android:text="Back" />
+            app:srcCompat="@android:drawable/ic_menu_revert" />
 
-        <Button
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/refreshButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
-            android:text="Refresh" />
+            app:srcCompat="@drawable/ic_refresh" />
 
-        <Button
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/offButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- convert speed test page buttons to material floating action buttons
- update `SpeedTestActivity` to reference the new views

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849bc31dab483339d02660c2598a7cb