### PR TITLE
Add IME action handling on setup screen

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -2,6 +2,7 @@ package com.example.routermanager
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
@@ -20,6 +21,16 @@ class SetupActivity : AppCompatActivity() {
         setContentView(R.layout.activity_setup)
         val urlField: EditText = findViewById(R.id.urlEditText)
         val accessButton: Button = findViewById(R.id.accessButton)
+
+        urlField.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                accessButton.performClick()
+                true
+            } else {
+                false
+            }
+        }
+
         accessButton.setOnClickListener {
             val url = urlField.text.toString().trim()
             val editor = prefs.edit()

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -10,6 +10,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:hint="Router URL"
+        android:singleLine="true"
+        android:imeOptions="actionDone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
## Summary
- make the URL field single-line and trigger Done action
- perform the Access button logic when the keyboard Done key is pressed

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849bed1293883339552352719a287ae