### PR TITLE
Fix load error handling and UI cleanup

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -18,6 +18,7 @@ import android.graphics.Bitmap
 import android.view.View
 import android.widget.ProgressBar
 import android.content.Intent
+import com.example.routermanager.EXTRA_FORCE_SETUP
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
@@ -88,7 +89,7 @@ class MainActivity : AppCompatActivity() {
             super.onReceivedError(view, request, error)
             if (request.isForMainFrame) {
                 progressBar.visibility = View.GONE
-                showLoadError(error.description)
+                showLoadError()
             }
         }
 
@@ -103,17 +104,19 @@ class MainActivity : AppCompatActivity() {
             val currentUrl = view?.url
             if (currentUrl != null && currentUrl == failingUrl) {
                 progressBar.visibility = View.GONE
-                showLoadError(description)
+                showLoadError()
             }
         }
     }
 
-    private fun showLoadError(description: CharSequence?) {
+    private fun showLoadError() {
         AlertDialog.Builder(this)
             .setTitle("Page Load Error")
-            .setMessage("The page could not be loaded:\n$description")
+            .setMessage("Unable to load the router page. Please check the address and try again.")
             .setPositiveButton("Back to Setup") { _, _ ->
-                startActivity(Intent(this, SetupActivity::class.java))
+                val intent = Intent(this, SetupActivity::class.java)
+                intent.putExtra(EXTRA_FORCE_SETUP, true)
+                startActivity(intent)
                 finish()
             }
             .setCancelable(false)
@@ -132,7 +135,6 @@ class MainActivity : AppCompatActivity() {
         val webView: WebView = findViewById(R.id.routerWebView)
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val speedTestButton: FloatingActionButton = findViewById(R.id.speedTestButton)
-        val homeButton: FloatingActionButton = findViewById(R.id.homeButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
         progressBar = findViewById(R.id.loadingProgress)
         webView.webViewClient = RouterWebViewClient()
@@ -186,9 +188,6 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, SpeedTestActivity::class.java))
         }
 
-        homeButton.setOnClickListener {
-            webView.loadUrl(routerUrl)
-        }
 
         offButton.setOnClickListener {
             prefs.edit().clear().apply()

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -7,19 +7,22 @@ import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 
+const val EXTRA_FORCE_SETUP = "forceSetup"
 private const val KEY_ROUTER_URL = "routerUrl"
 
 class SetupActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val forceSetup = intent.getBooleanExtra(EXTRA_FORCE_SETUP, false)
         val prefs = getSharedPreferences("settings", MODE_PRIVATE)
-        if (prefs.contains(KEY_ROUTER_URL)) {
+        if (!forceSetup && prefs.contains(KEY_ROUTER_URL)) {
             startActivity(Intent(this, MainActivity::class.java))
             finish()
             return
         }
         setContentView(R.layout.activity_setup)
         val urlField: EditText = findViewById(R.id.urlEditText)
+        urlField.setText(prefs.getString(KEY_ROUTER_URL, ""))
         val accessButton: Button = findViewById(R.id.accessButton)
 
         urlField.setOnEditorActionListener { _, actionId, _ ->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,12 +35,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/homeButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            app:srcCompat="@android:drawable/ic_menu_revert" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/refreshButton"


### PR DESCRIPTION
## Summary
- show a clear message when the router page fails to load and offer a working "Back to Setup" action
- keep previously entered router URL when returning to Setup
- hide the unnecessary back button on the main page

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb1807c883339311c084a9a1b024