### PR TITLE
Add power icon and accessibility updates

### DIFF
--- a/app/src/main/res/drawable/ic_power.xml
+++ b/app/src/main/res/drawable/ic_power.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M13 3h-2v10h2V3zM17.83 5.17l-1.42 1.41A7 7 0 1 1 6.76 6.58L5.34 5.17A8.97 8.97 0 0 0 3 11a9 9 0 1 0 18 0c0-2.41-.95-4.6-2.5-6.22z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,6 +41,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:contentDescription="@string/action_refresh"
             app:srcCompat="@drawable/ic_refresh" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -48,13 +49,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:contentDescription="@string/action_speed_test"
             app:srcCompat="@android:drawable/ic_menu_manage" />
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/offButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Off" />
+            android:contentDescription="@string/action_power_off"
+            app:icon="@drawable/ic_power" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -28,6 +28,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:contentDescription="@string/action_back"
             app:srcCompat="@android:drawable/ic_menu_revert" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -35,12 +36,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:contentDescription="@string/action_refresh"
             app:srcCompat="@drawable/ic_refresh" />
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/offButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Off" />
+            android:contentDescription="@string/action_power_off"
+            app:icon="@drawable/ic_power" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">RouterManager</string>
+    <string name="action_refresh">Refresh</string>
+    <string name="action_speed_test">Speed Test</string>
+    <string name="action_back">Back</string>
+    <string name="action_power_off">Power Off</string>
 </resources>


### PR DESCRIPTION
## Summary
- add new `ic_power` vector drawable
- hook up new icon in Main and Speed Test layouts
- remove text from Extended FAB and set content descriptions for all FABs
- add string resources for button labels

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849c711d01083339fbf55c657e5e95c