### PR TITLE
Add expandable button menus

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -136,6 +136,8 @@ class MainActivity : AppCompatActivity() {
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val speedTestButton: FloatingActionButton = findViewById(R.id.speedTestButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
+        val buttonContainer: View = findViewById(R.id.buttonContainer)
+        val toggleFab: FloatingActionButton = findViewById(R.id.toggleFab)
         progressBar = findViewById(R.id.loadingProgress)
         webView.webViewClient = RouterWebViewClient()
         webView.webChromeClient = object : WebChromeClient() {
@@ -188,6 +190,24 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, SpeedTestActivity::class.java))
         }
 
+        toggleFab.setOnClickListener {
+            val visible = buttonContainer.visibility == View.VISIBLE
+            if (visible) {
+                buttonContainer.animate()
+                    .alpha(0f)
+                    .setDuration(200)
+                    .withEndAction { buttonContainer.visibility = View.GONE }
+                    .start()
+                toggleFab.setImageResource(android.R.drawable.ic_menu_more)
+                toggleFab.contentDescription = getString(R.string.action_expand)
+            } else {
+                buttonContainer.alpha = 0f
+                buttonContainer.visibility = View.VISIBLE
+                buttonContainer.animate().alpha(1f).setDuration(200).start()
+                toggleFab.setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
+                toggleFab.contentDescription = getString(R.string.action_collapse)
+            }
+        }
 
         offButton.setOnClickListener {
             prefs.edit { clear() }

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.webkit.WebSettings
 import android.webkit.CookieManager
 import androidx.core.content.edit
+import android.view.View
 
 class SpeedTestActivity : AppCompatActivity() {
     @SuppressLint("SetJavaScriptEnabled")
@@ -21,6 +22,8 @@ class SpeedTestActivity : AppCompatActivity() {
         val backButton: FloatingActionButton = findViewById(R.id.backButton)
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
+        val buttonContainer: View = findViewById(R.id.buttonContainer)
+        val toggleFab: FloatingActionButton = findViewById(R.id.toggleFab)
 
         webView.settings.apply {
             javaScriptEnabled = true
@@ -35,6 +38,24 @@ class SpeedTestActivity : AppCompatActivity() {
         }
         refreshButton.setOnClickListener {
             webView.url?.let { currentUrl -> webView.loadUrl(currentUrl) }
+        }
+        toggleFab.setOnClickListener {
+            val visible = buttonContainer.visibility == View.VISIBLE
+            if (visible) {
+                buttonContainer.animate()
+                    .alpha(0f)
+                    .setDuration(200)
+                    .withEndAction { buttonContainer.visibility = View.GONE }
+                    .start()
+                toggleFab.setImageResource(android.R.drawable.ic_menu_more)
+                toggleFab.contentDescription = getString(R.string.action_expand)
+            } else {
+                buttonContainer.alpha = 0f
+                buttonContainer.visibility = View.VISIBLE
+                buttonContainer.animate().alpha(1f).setDuration(200).start()
+                toggleFab.setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
+                toggleFab.contentDescription = getString(R.string.action_collapse)
+            }
         }
         offButton.setOnClickListener {
             getSharedPreferences("settings", MODE_PRIVATE).edit { clear() }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,11 +26,13 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="end"
         android:orientation="horizontal"
         android:padding="16dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
@@ -59,6 +61,16 @@
             android:contentDescription="@string/action_power_off"
             app:icon="@drawable/ic_power" />
 
-    </LinearLayout>
+</LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/toggleFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/action_expand"
+        app:srcCompat="@android:drawable/ic_menu_more"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -14,11 +14,13 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="end"
         android:padding="16dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
@@ -46,4 +48,14 @@
             android:contentDescription="@string/action_power_off"
             app:icon="@drawable/ic_power" />
     </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/toggleFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/action_expand"
+        app:srcCompat="@android:drawable/ic_menu_more"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="action_speed_test">Speed Test</string>
     <string name="action_back">Back</string>
     <string name="action_power_off">Power Off</string>
+    <string name="action_expand">Expand</string>
+    <string name="action_collapse">Collapse</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `action_expand` and `action_collapse` strings
- wrap footer buttons in new containers
- add toggle FABs to layouts
- animate container visibility from activities

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7a8df7c8333bee9e06601a7baf5