### PR TITLE
Add resource strings for error dialogs

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -48,17 +48,17 @@ class MainActivity : AppCompatActivity() {
 
             if (pendingSslHandlers.size == 1) {
                 AlertDialog.Builder(this@MainActivity)
-                    .setTitle("SSL Certificate Error")
+                    .setTitle(getString(R.string.ssl_certificate_error_title))
                     .setMessage(
-                        "The router presented an untrusted certificate. Continue anyway?"
+                        getString(R.string.ssl_certificate_error_message)
                     )
-                    .setPositiveButton("Continue") { _, _ ->
+                    .setPositiveButton(getString(R.string.action_continue)) { _, _ ->
                         sslTrusted = true
                         prefs.edit { putBoolean(PrefsKeys.KEY_SSL_TRUSTED, true) }
                         pendingSslHandlers.forEach { it.proceed() }
                         pendingSslHandlers.clear()
                     }
-                    .setNegativeButton("Cancel") { _, _ ->
+                    .setNegativeButton(getString(R.string.action_cancel)) { _, _ ->
                         prefs.edit { remove(PrefsKeys.KEY_SSL_TRUSTED) }
                         pendingSslHandlers.forEach { it.cancel() }
                         pendingSslHandlers.clear()
@@ -109,9 +109,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun showLoadError() {
         AlertDialog.Builder(this)
-            .setTitle("Page Load Error")
-            .setMessage("Unable to load the router page. Please check the address and try again.")
-            .setPositiveButton("Back to Setup") { _, _ ->
+            .setTitle(getString(R.string.page_load_error_title))
+            .setMessage(getString(R.string.page_load_error_message))
+            .setPositiveButton(getString(R.string.action_back_to_setup)) { _, _ ->
                 val intent = Intent(this, SetupActivity::class.java)
                 intent.putExtra(EXTRA_FORCE_SETUP, true)
                 startActivity(intent)

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -23,7 +23,7 @@
         android:id="@+id/urlEditText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:hint="Router URL"
+        android:hint="@string/hint_router_url"
         android:singleLine="true"
         android:imeOptions="actionDone"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,12 @@
     <string name="action_power_off">Power Off</string>
     <string name="action_expand">Expand</string>
     <string name="action_collapse">Collapse</string>
+    <string name="ssl_certificate_error_title">SSL Certificate Error</string>
+    <string name="ssl_certificate_error_message">The router presented an untrusted certificate. Continue anyway?</string>
+    <string name="action_continue">Continue</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="page_load_error_title">Page Load Error</string>
+    <string name="page_load_error_message">Unable to load the router page. Please check the address and try again.</string>
+    <string name="action_back_to_setup">Back to Setup</string>
+    <string name="hint_router_url">Router URL</string>
 </resources>


### PR DESCRIPTION
## Summary
- add new strings for SSL and page load errors
- update `activity_setup.xml` to use a hint string
- replace hardcoded alert text with string resources

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849c957b1bc83339b81a3da1d6bc6de