### PR TITLE
Use app icon in setup screen

### DIFF
--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -10,13 +10,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/router_image_description"
-        android:src="@drawable/ic_router"
+        android:src="@mipmap/ic_launcher"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintWidth_percent="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/urlEditText"
+        app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintVertical_bias="0.4" />
 
     <EditText
@@ -29,17 +30,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/routerImageView"
-        app:layout_constraintBottom_toTopOf="@+id/accessButton" />
+        app:layout_constraintBottom_toTopOf="@+id/accessButton"
+        android:layout_marginTop="16dp" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/accessButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@string/action_access"
-        app:srcCompat="@drawable/ic_router"
+        app:srcCompat="@mipmap/ic_launcher"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/urlEditText"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="16dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- tweak Setup screen to use the existing app launcher icon
- pack the setup screen widgets together to avoid large gaps

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd03ce0083338162eecbd7a1db0b