### PR TITLE
Auto-detect router address during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 
 ## Launching the WebView App
 
-After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen where you can enter your router's URL and tap **Access**. The WebView automatically loads this saved address on future launches, defaulting to `https://10.80.80.1/` if no value was provided.
+After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen where you can enter your router's URL and tap **Access**. The app now attempts to detect your gateway automatically, briefly showing a spinner while the URL field is populated. The WebView automatically loads this saved address on future launches, defaulting to `https://10.80.80.1/` if no value was provided.
 
 You may also open the project in Android Studio and run it directly from there using the built-in Gradle wrapper support.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.example.routermanager">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:name=".RouterManagerApplication"

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -2,8 +2,12 @@ package com.example.routermanager
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
+import android.widget.ProgressBar
+import android.net.wifi.WifiManager
+import android.text.format.Formatter
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
@@ -22,8 +26,24 @@ class SetupActivity : AppCompatActivity() {
         }
         setContentView(R.layout.activity_setup)
         val urlField: EditText = findViewById(R.id.urlEditText)
+        val progress: ProgressBar = findViewById(R.id.setupProgress)
         urlField.setText(prefs.getString(PrefsKeys.KEY_ROUTER_URL, ""))
         val accessButton: FloatingActionButton = findViewById(R.id.accessButton)
+
+        urlField.isEnabled = false
+        progress.visibility = View.VISIBLE
+        Thread {
+            val wifi = applicationContext.getSystemService(WIFI_SERVICE) as? WifiManager
+            val address = wifi?.dhcpInfo?.gateway?.takeIf { it != 0 }?.let {
+                @Suppress("DEPRECATION")
+                Formatter.formatIpAddress(it)
+            }
+            runOnUiThread {
+                address?.let { urlField.setText("https://$it/") }
+                progress.visibility = View.GONE
+                urlField.isEnabled = true
+            }
+        }.start()
 
         urlField.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE) {

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -30,8 +30,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/routerImageView"
-        app:layout_constraintBottom_toTopOf="@+id/accessButton"
+        app:layout_constraintBottom_toTopOf="@+id/setupProgress"
         android:layout_marginTop="16dp" />
+
+    <ProgressBar
+        android:id="@+id/setupProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/urlEditText"
+        app:layout_constraintBottom_toTopOf="@+id/accessButton" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/accessButton"
@@ -41,7 +52,7 @@
         app:srcCompat="@drawable/ic_power"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/urlEditText"
+        app:layout_constraintTop_toBottomOf="@id/setupProgress"
         app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginTop="16dp" />
 


### PR DESCRIPTION
## Summary
- allow reading Wi-Fi information
- show a progress indicator while the gateway is scanned
- automatically populate the router URL once discovered
- document automatic scanning behaviour

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbdfb8cc8333bbbd145e3195009b