### PR TITLE
Make URL field read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RouterManager
 
-RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. When the app runs for the first time it shows an initial setup screen prompting for the router URL. The address you enter is stored for future launches and can be reset later using the **Off** button. If nothing is provided the app falls back to `https://10.80.80.1/`.
+RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. On first launch the app automatically scans your network and populates the router URL. This address is stored for future launches and can be reset later using the **Off** button. If scanning fails, the app falls back to `https://10.80.80.1/`.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 
 ## Launching the WebView App
 
-After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen where you can enter your router's URL and tap **Access**. The app now attempts to detect your gateway automatically, briefly showing a spinner while the URL field is populated. The WebView automatically loads this saved address on future launches, defaulting to `https://10.80.80.1/` if no value was provided.
+After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen while the app automatically scans for your router. The URL field is read-only and will be populated once the gateway is detected. Tap **Access** to continue. The WebView automatically loads this saved address on future launches, defaulting to `https://10.80.80.1/` if scanning fails.
 
 You may also open the project in Android Studio and run it directly from there using the built-in Gradle wrapper support.
 

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -3,7 +3,6 @@ package com.example.routermanager
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.net.wifi.WifiManager
@@ -41,18 +40,8 @@ class SetupActivity : AppCompatActivity() {
             runOnUiThread {
                 address?.let { urlField.setText("https://$it/") }
                 progress.visibility = View.GONE
-                urlField.isEnabled = true
             }
         }.start()
-
-        urlField.setOnEditorActionListener { _, actionId, _ ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                accessButton.performClick()
-                true
-            } else {
-                false
-            }
-        }
 
         accessButton.setOnClickListener {
             val url = urlField.text.toString().trim()


### PR DESCRIPTION
## Summary
- keep the URL field disabled after network scanning completes
- remove unused `EditorInfo` import and listener
- clarify in the README that the address field is read-only

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849df467ab0833392f492c42d7526fc