### PR TITLE
Remove default router URL, credit author

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RouterManager
 
-RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. On first launch the app automatically scans your network and populates the router URL. This address is stored for future launches and can be reset later using the **Off** button. If scanning fails, the app falls back to `https://10.80.80.1/`.
+RouterManager is a simple Android application that opens a WebView pointing to your router's management interface. On first launch the app automatically scans your network and populates the router URL. This address is stored for future launches and can be reset later using the **Off** button.
 
 ## Prerequisites
 
@@ -21,9 +21,13 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 
 ## Launching the WebView App
 
-After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen while the app automatically scans for your router. The URL field is read-only and will be populated once the gateway is detected. Tap **Access** to continue. The WebView automatically loads this saved address on future launches, defaulting to `https://10.80.80.1/` if scanning fails.
+After installing the APK on your device, launch the **RouterManager** application. On the first run you'll see the setup screen while the app automatically scans for your router. The URL field is read-only and will be populated once the gateway is detected. Tap **Access** to continue. The WebView automatically loads this saved address on future launches.
 
 You may also open the project in Android Studio and run it directly from there using the built-in Gradle wrapper support.
+
+## Author
+
+RouterManager is maintained by Amir Al Hafiz.
 
 ## License
 

--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -25,8 +25,6 @@ import com.google.android.material.floatingactionbutton.ExtendedFloatingActionBu
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.core.view.isVisible
 
-private const val DEFAULT_ROUTER_URL = "https://10.80.80.1/"
-
 class MainActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var prefs: SharedPreferences
@@ -127,8 +125,8 @@ class MainActivity : AppCompatActivity() {
         prefs = getSharedPreferences("settings", MODE_PRIVATE)
         sslTrusted = savedInstanceState?.getBoolean(PrefsKeys.KEY_SSL_TRUSTED)
             ?: prefs.getBoolean(PrefsKeys.KEY_SSL_TRUSTED, false)
-        val routerUrl = prefs.getString(PrefsKeys.KEY_ROUTER_URL, DEFAULT_ROUTER_URL)
-            ?: DEFAULT_ROUTER_URL
+        val routerUrl = prefs.getString(PrefsKeys.KEY_ROUTER_URL, "")
+            ?: ""
         setContentView(R.layout.activity_main)
 
         val webView: WebView = findViewById(R.id.routerWebView)


### PR DESCRIPTION
## Summary
- remove hardcoded default router URL and rely entirely on the value detected during setup
- update documentation to remove fallback mention and credit Amir Al Hafiz as the author

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849db14a438833391741318dac288f6