### PR TITLE
Fix gateway scanning button state

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -30,6 +30,7 @@ class SetupActivity : AppCompatActivity() {
         val accessButton: FloatingActionButton = findViewById(R.id.accessButton)
 
         urlField.isEnabled = false
+        accessButton.isEnabled = false
         progress.visibility = View.VISIBLE
         Thread {
             val wifi = applicationContext.getSystemService(WIFI_SERVICE) as? WifiManager
@@ -40,6 +41,9 @@ class SetupActivity : AppCompatActivity() {
             runOnUiThread {
                 address?.let { urlField.setText("https://$it/") }
                 progress.visibility = View.GONE
+                if (address != null || urlField.text.isNotBlank()) {
+                    accessButton.isEnabled = true
+                }
             }
         }.start()
 


### PR DESCRIPTION
## Summary
- disable Access button while scanning for the gateway
- only enable the button after scanning when a URL is available

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2ae3f388333a61e6f84047a8892