### PR TITLE
Hide button container

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
         android:gravity="end"
         android:orientation="horizontal"
         android:padding="16dp"
-        android:visibility="visible"
+        android:visibility="gone"
         android:layout_marginEnd="56dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -21,7 +21,7 @@
         android:orientation="horizontal"
         android:gravity="end"
         android:padding="16dp"
-        android:visibility="visible"
+        android:visibility="gone"
         android:layout_marginEnd="56dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Summary
- hide button container at start in main and speed test screens
- confirm FloatingActionButton already uses expand icon

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849e31b702c8333b05829874686dc5b