### PR TITLE
Fix BuildConfig import in SetupActivity

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -11,6 +11,7 @@ import android.text.format.Formatter
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
+import com.example.routermanager.BuildConfig
 
 const val EXTRA_FORCE_SETUP = "forceSetup"
 


### PR DESCRIPTION
## Summary
- import `BuildConfig` explicitly in `SetupActivity`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849f308588c833387c0087350b2b294