### PR TITLE
Update versioning from git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Use the provided Gradle wrapper scripts to build or install the app. On Unix sys
 ./gradlew installDebug
 ```
 
+## Versioning
+
+The build script derives the app's version from the Git commit history. During
+configuration it runs `git rev-list --count HEAD` to calculate a commit count.
+This value becomes the `versionCode` and is appended to `1.` to form the
+`versionName`. As a result, version numbers change whenever the repository's
+history changes.
+
 ## Running Instrumentation Tests
 
 Ensure a device or emulator is connected and run:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,12 @@ android {
     namespace "com.example.routermanager"
 
     defaultConfig {
+        def commitCount = "git rev-list --count HEAD".execute([], rootDir).text.trim().toInteger()
         applicationId "com.example.routermanager"
         minSdk 21
         targetSdk 35
-        versionCode 1
-        versionName "1.0"
+        versionCode commitCount
+        versionName "1.${commitCount}"
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- derive versionCode and versionName from `git rev-list --count HEAD`
- document automatic versioning in README

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849f5673cb48333a03ae7d908f23bd4