### PR TITLE
Handle missing Git info in version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,16 @@ android {
     namespace "com.example.routermanager"
 
     defaultConfig {
-        def commitCount = "git rev-list --count HEAD".execute([], rootDir).text.trim().toInteger()
-        def gitSha = "git rev-parse --short HEAD".execute([], rootDir).text.trim()
+        def commitCount
+        def gitSha
+        try {
+            commitCount = "git rev-list --count HEAD".execute([], rootDir).text.trim().toInteger()
+            gitSha = "git rev-parse --short HEAD".execute([], rootDir).text.trim()
+        } catch (Exception e) {
+            logger.warn("Git info not available, using default version values")
+            commitCount = 1
+            gitSha = 'dev'
+        }
 
         def index = commitCount - 1
         def major = index.intdiv(100)


### PR DESCRIPTION
## Summary
- fallback to default commit count and git sha when git commands fail

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc0049748333bad6563c2b4e785c