### PR TITLE
Add SpeedTestActivity instrumentation tests

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -1,0 +1,49 @@
+package com.example.routermanager
+
+import android.webkit.WebView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SpeedTestActivityTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(SpeedTestActivity::class.java)
+
+    @Test
+    fun webViewLoadsExpectedUrl() {
+        onView(withId(R.id.speedTestWebView)).check { view, noViewFoundException ->
+            if (noViewFoundException != null) throw noViewFoundException
+            val webView = view as WebView
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            assertEquals("https://www.speedtest.net/", webView.url)
+        }
+    }
+
+    @Test
+    fun toggleFabTogglesButtonsVisibility() {
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.toggleFab)).perform(click())
+
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        onView(withId(R.id.toggleFab)).perform(click())
+
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for SpeedTestActivity to ensure WebView opens `https://www.speedtest.net/`
- verify toggle button shows and hides the control buttons

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc62b7788333bac05e5a267a909b