### PR TITLE
Use lifecycle coroutine for gateway lookup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }


### PR DESCRIPTION
## Summary
- replace the gateway discovery thread with a `lifecycleScope` coroutine
- add coroutine/lifecycle dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a5172fb3083338221d20bf5438b05