### PR TITLE
Add inputType to URL field

### DIFF
--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -26,6 +26,7 @@
         android:layout_height="wrap_content"
         android:hint="@string/hint_router_url"
         android:singleLine="true"
+        android:inputType="textUri"
         android:imeOptions="actionDone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Summary
- specify `textUri` input type for the URL entry field

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a586aba58833399b4a7948a31c3f1