### PR TITLE
Update Java target to 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,11 +39,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig = true


### PR DESCRIPTION
## Summary
- use Java 17 for `compileOptions` and Kotlin `jvmTarget`

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a5bfa20ec8333b1b3221f70b45dee