### PR TITLE
Add ProGuard rules for release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ v0.01.01-ghi789
 ```
 
 ---
+## 🔒 ProGuard & Release Builds
+
+Release builds can be minified with ProGuard. The rules in `app/proguard-rules.pro` keep WebView classes, Kotlin coroutines and Material dynamic color utilities while stripping debug logs.
+Minification is disabled by default so `assembleRelease` works out of the box.
+
 
 ## ✅ Running Instrumentation Tests
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,38 @@
+# ProGuard rules for RouterManager
+#
+# These rules keep WebView client implementations and other
+# dependencies used by the app when minification is enabled.
+
+# Keep custom WebViewClient and WebChromeClient subclasses
+-keep public class * extends android.webkit.WebViewClient {
+    public <init>(...);
+    public *;
+}
+-keep public class * extends android.webkit.WebChromeClient {
+    public <init>(...);
+    public *;
+}
+
+# Preserve methods annotated with @JavascriptInterface (none currently,
+# but this rule is harmless and future proof).
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+# Material Components dynamic color support
+-keep class com.google.android.material.color.DynamicColors { *; }
+
+# Kotlin coroutines are heavily used; keep their metadata to avoid
+# reflection issues during minification.
+-keep class kotlinx.coroutines.** { *; }
+-dontwarn kotlinx.coroutines.**
+
+# General AndroidX and appcompat rules (safe defaults)
+-keep class androidx.lifecycle.** { *; }
+-keep class androidx.appcompat.widget.** { *; }
+
+# Optimize by removing logging
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+}


### PR DESCRIPTION
## Summary
- add keep rules for WebView clients, DynamicColors and Kotlin coroutines
- mention ProGuard rules in the README

## Testing
- `./gradlew assembleRelease --no-daemon --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a6314c26c8333b65f21004a40ad8f