### PR TITLE
Refine router setup and HTTPS handling

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -177,7 +177,23 @@ class MainActivity : AppCompatActivity() {
             CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
         }
 
-        webView.loadUrl(routerUrl)
+        if (routerUrl.startsWith("https://") && !sslTrusted) {
+            AlertDialog.Builder(this)
+                .setTitle(getString(R.string.ssl_certificate_error_title))
+                .setMessage(getString(R.string.ssl_certificate_error_message))
+                .setPositiveButton(getString(R.string.action_continue)) { _, _ ->
+                    sslTrusted = true
+                    prefs.edit { putBoolean(PrefsKeys.KEY_SSL_TRUSTED, true) }
+                    webView.loadUrl(routerUrl)
+                }
+                .setNegativeButton(getString(R.string.action_cancel)) { _, _ ->
+                    finish()
+                }
+                .setCancelable(false)
+                .show()
+        } else {
+            webView.loadUrl(routerUrl)
+        }
 
         refreshButton.setOnClickListener {
             webView.url?.let { currentUrl -> webView.loadUrl(currentUrl) }
@@ -196,11 +212,6 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, SetupActivity::class.java))
             finish()
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        webView.url?.let { webView.loadUrl(it) }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false" />
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>


### PR DESCRIPTION
## Summary
- determine router protocol using port checks during auto-scan
- keep URL editable after scanning
- ask for HTTPS trust before loading the router page
- allow HTTP connections
- stop reloading web page on resume

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a64d8e9988333a6d78532887d5fd5