### PR TITLE
Use ConnectivityManager for IP detection

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -48,16 +48,16 @@ class SetupActivity : AppCompatActivity() {
         progress.visibility = View.VISIBLE
         lifecycleScope.launch {
             val address = withContext(Dispatchers.IO) {
-                val wifi = applicationContext.getSystemService(WIFI_SERVICE) as? WifiManager
                 val connectivity = applicationContext.getSystemService(CONNECTIVITY_SERVICE) as? ConnectivityManager
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    val network = wifi?.currentNetwork
+                    val network = connectivity?.activeNetwork
                     connectivity?.getLinkProperties(network)
                         ?.routes
                         ?.firstOrNull { it.isDefaultRoute }
                         ?.gateway
                         ?.hostAddress
                 } else {
+                    val wifi = applicationContext.getSystemService(WIFI_SERVICE) as? WifiManager
                     @Suppress("DEPRECATION")
                     wifi?.dhcpInfo?.gateway?.takeIf { it != 0 }?.let { gateway ->
                         val bytes = ByteBuffer.allocate(4)


### PR DESCRIPTION
## Summary
- remove WifiManager usage for API 31+
- retrieve active network from ConnectivityManager
- keep WifiManager only for pre-31 gateway fallback

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a748db82c833390b355c24586de2a