### PR TITLE
Fix page reload after JS confirm

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -159,7 +159,10 @@ class MainActivity : AppCompatActivity() {
             ): Boolean {
                 AlertDialog.Builder(this@MainActivity)
                     .setMessage(message)
-                    .setPositiveButton(android.R.string.ok) { _, _ -> result?.confirm() }
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        result?.confirm()
+                        webView.postDelayed({ webView.reload() }, 500)
+                    }
                     .setNegativeButton(android.R.string.cancel) { _, _ -> result?.cancel() }
                     .setCancelable(false)
                     .show()


### PR DESCRIPTION
## Summary
- refresh router page after confirming JavaScript dialogs
- wait briefly before reloading so actions complete first

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_684a6bfc9de88333b54a8ec7bb724275