### PR TITLE
Fix IPv6 detection for setup page

### DIFF
--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -12,6 +12,7 @@ import android.net.wifi.WifiManager
 import android.net.ConnectivityManager
 import android.os.Build
 import java.net.InetAddress
+import java.net.Inet4Address
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -53,7 +54,7 @@ class SetupActivity : AppCompatActivity() {
                     val network = connectivity?.activeNetwork
                     connectivity?.getLinkProperties(network)
                         ?.routes
-                        ?.firstOrNull { it.isDefaultRoute }
+                        ?.firstOrNull { it.isDefaultRoute && it.gateway is Inet4Address }
                         ?.gateway
                         ?.hostAddress
                 } else {


### PR DESCRIPTION
## Summary
- restrict default route detection to IPv4 gateways

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a82506e7c8333a60fa3f350262db3