### PR TITLE
Open setup on SSL cancel

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -189,6 +189,9 @@ class MainActivity : AppCompatActivity() {
                     webView.loadUrl(routerUrl)
                 }
                 .setNegativeButton(getString(R.string.action_cancel)) { _, _ ->
+                    val intent = Intent(this, SetupActivity::class.java)
+                    intent.putExtra(EXTRA_FORCE_SETUP, true)
+                    startActivity(intent)
                     finish()
                 }
                 .setCancelable(false)


### PR DESCRIPTION
## Summary
- tweak negative button handler in `MainActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8420d7f88333b4715913b10bdfd5