### PR TITLE
Keep URL field read-only after scan

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
@@ -6,7 +6,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.hamcrest.Matchers.not
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
 import org.junit.Test
@@ -27,5 +29,12 @@ class SetupActivityTest {
     @Test
     fun setupScreenShowsBigIcon() {
         onView(withId(R.id.routerImageView)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun urlFieldRemainsDisabledAfterScan() {
+        // Wait for the asynchronous network detection to complete
+        Thread.sleep(3000)
+        onView(withId(R.id.urlEditText)).check(matches(not(isEnabled())))
     }
 }

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -79,7 +79,7 @@ class SetupActivity : AppCompatActivity() {
                 }
             }
             withContext(Dispatchers.Main) {
-                urlField.isEnabled = true
+                // Keep the URL field read‑only after network detection completes
                 address?.let { urlField.setText("${scheme ?: "http://"}$it/") }
                 progress.visibility = View.GONE
                 if (address != null || urlField.text.isNotBlank()) {


### PR DESCRIPTION
## Summary
- keep URL field disabled after network detection
- verify the field remains disabled via instrumentation test

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew connectedAndroidTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8490baa88333bf58b0abe6545cfd