### PR TITLE
Add progress indicator for speed test

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -45,5 +45,23 @@ class SpeedTestActivityTest {
         onView(withId(R.id.buttonContainer))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
     }
+
+    @Test
+    fun progressBarTogglesOnPageLoad() {
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.refreshButton)).perform(click())
+
+        Thread.sleep(1000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        Thread.sleep(3000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
 }
 

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -3,6 +3,9 @@ package com.example.routermanager
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceError
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import androidx.appcompat.app.AppCompatActivity
@@ -11,19 +14,48 @@ import android.webkit.WebSettings
 import android.webkit.CookieManager
 import androidx.core.content.edit
 import android.view.View
+import android.widget.ProgressBar
+import android.graphics.Bitmap
 
 class SpeedTestActivity : AppCompatActivity() {
+    private lateinit var progressBar: ProgressBar
+
+    private inner class SpeedTestWebViewClient : WebViewClient() {
+        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+            super.onPageStarted(view, url, favicon)
+            progressBar.visibility = View.VISIBLE
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            super.onPageFinished(view, url)
+            progressBar.visibility = View.GONE
+        }
+
+        override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError
+        ) {
+            super.onReceivedError(view, request, error)
+            if (request.isForMainFrame) {
+                progressBar.visibility = View.GONE
+            }
+        }
+    }
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_speed_test)
 
         val webView: WebView = findViewById(R.id.speedTestWebView)
+        progressBar = findViewById(R.id.loadingProgress)
         val backButton: FloatingActionButton = findViewById(R.id.backButton)
         val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
         val buttonContainer: View = findViewById(R.id.buttonContainer)
         val toggleFab: FloatingActionButton = findViewById(R.id.toggleFab)
+
+        webView.webViewClient = SpeedTestWebViewClient()
 
         webView.settings.apply {
             javaScriptEnabled = true

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -14,6 +14,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <ProgressBar
+        android:id="@+id/loadingProgress"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:indeterminate="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <LinearLayout
         android:id="@+id/buttonContainer"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- show a loading spinner when the speed test page loads
- track progress visibility in `SpeedTestActivity`
- exercise new progress bar logic in instrumentation tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8a9b38808333ac98f07f9597afc7