### PR TITLE
Add progress bar UI tests

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
@@ -57,4 +57,22 @@ class MainActivityTest {
         onView(withId(R.id.buttonContainer))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
     }
+
+    @Test
+    fun progressBarTogglesOnPageLoad() {
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.refreshButton)).perform(click())
+
+        Thread.sleep(1000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        Thread.sleep(3000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
 }

--- a/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
@@ -8,6 +8,8 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import org.hamcrest.Matchers.not
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
@@ -36,5 +38,16 @@ class SetupActivityTest {
         // Wait for the asynchronous network detection to complete
         Thread.sleep(3000)
         onView(withId(R.id.urlEditText)).check(matches(not(isEnabled())))
+    }
+
+    @Test
+    fun progressBarShowsAndHidesDuringScan() {
+        onView(withId(R.id.setupProgress))
+            .check(matches(isDisplayed()))
+
+        Thread.sleep(3000)
+
+        onView(withId(R.id.setupProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
     }
 }


### PR DESCRIPTION
## Summary
- test MainActivity progress bar toggles when pages refresh
- check SetupActivity progress bar visibility while scanning
- confirm SpeedTestActivity progress bar toggle behaviour remains

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b44b0708333aede3eba0152cf9b