### PR TITLE
Use Espresso IdlingResource in SetupActivity tests

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SetupActivityTest.kt
@@ -5,11 +5,16 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.annotation.IdRes
+import android.view.View
+import androidx.test.core.app.ActivityScenario
 import org.hamcrest.Matchers.not
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
@@ -35,9 +40,10 @@ class SetupActivityTest {
 
     @Test
     fun urlFieldRemainsDisabledAfterScan() {
-        // Wait for the asynchronous network detection to complete
-        Thread.sleep(3000)
+        val resource = ProgressGoneIdlingResource(activityRule.scenario, R.id.setupProgress)
+        IdlingRegistry.getInstance().register(resource)
         onView(withId(R.id.urlEditText)).check(matches(not(isEnabled())))
+        IdlingRegistry.getInstance().unregister(resource)
     }
 
     @Test
@@ -45,9 +51,38 @@ class SetupActivityTest {
         onView(withId(R.id.setupProgress))
             .check(matches(isDisplayed()))
 
-        Thread.sleep(3000)
+        val resource = ProgressGoneIdlingResource(activityRule.scenario, R.id.setupProgress)
+        IdlingRegistry.getInstance().register(resource)
 
         onView(withId(R.id.setupProgress))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        IdlingRegistry.getInstance().unregister(resource)
+    }
+}
+
+private class ProgressGoneIdlingResource(
+    private val scenario: ActivityScenario<*>,
+    @IdRes private val viewId: Int
+) : IdlingResource {
+    @Volatile
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    override fun getName(): String = "ProgressGoneIdlingResource:$viewId"
+
+    override fun isIdleNow(): Boolean {
+        var idle = false
+        scenario.onActivity { activity ->
+            val view = activity.findViewById<View>(viewId)
+            idle = view.visibility == View.GONE
+        }
+        if (idle) {
+            callback?.onTransitionToIdle()
+        }
+        return idle
+    }
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+        this.callback = callback
     }
 }


### PR DESCRIPTION
## Summary
- add a custom `ProgressGoneIdlingResource`
- replace `Thread.sleep` with the idling resource in `SetupActivityTest`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8c073d688333baf3ebc2667c69f2