### PR TITLE
Add loading string and content descriptions

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         android:indeterminate="true"
+        android:contentDescription="@string/loading"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -39,6 +39,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:indeterminate="true"
+        android:contentDescription="@string/loading"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         android:indeterminate="true"
+        android:contentDescription="@string/loading"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -18,4 +18,5 @@
     <string name="action_back_to_setup">Volver a configuración</string>
     <string name="hint_router_url">URL del router</string>
     <string name="version_format">Versión %1$s</string>
+    <string name="loading">Cargando...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="action_back_to_setup">Back to Setup</string>
     <string name="hint_router_url">Router URL</string>
     <string name="version_format">Version %1$s</string>
+    <string name="loading">Loading...</string>
 </resources>


### PR DESCRIPTION
## Summary
- add missing "loading" string in English and Spanish resources
- set contentDescription on ProgressBars used during page loading

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*
- `./gradlew connectedAndroidTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ee8dfa483339be8063f19d7ed6d