### PR TITLE
Add coroutine speed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Not all routers come with official mobile apps. Most rely on outdated web portal
 - ✅ Loads the web interface in a secure WebView
 - ✅ "Off" button to reset stored IP
 - ✅ Simple and intuitive interface
+- ✅ Built-in network speed test
 
 ---
 
@@ -118,7 +119,8 @@ Ensure a device or emulator is connected.
 3. On first run, the app scans your local network and auto-detects your router’s IP.
 4. The router IP is saved for future launches.
 5. Tap **Access** to open the WebView.
-6. Use the **Off** button to reset the saved address and re-trigger detection.
+6. Open the menu and tap **Run Test** to measure your network speed.
+7. Use the **Off** button to reset the saved address and re-trigger detection.
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -1,6 +1,5 @@
 package com.example.routermanager
 
-import android.webkit.WebView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
@@ -9,8 +8,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
-import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,13 +18,16 @@ class SpeedTestActivityTest {
     val activityRule = ActivityScenarioRule(SpeedTestActivity::class.java)
 
     @Test
-    fun webViewLoadsExpectedUrl() {
-        onView(withId(R.id.speedTestWebView)).check { view, noViewFoundException ->
-            if (noViewFoundException != null) throw noViewFoundException
-            val webView = view as WebView
-            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-            assertEquals("https://www.speedtest.net/", webView.url)
-        }
+    fun runButtonShowsProgress() {
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.runTestButton)).perform(click())
+
+        Thread.sleep(1000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     }
 
     @Test
@@ -47,18 +47,15 @@ class SpeedTestActivityTest {
     }
 
     @Test
-    fun progressBarTogglesOnPageLoad() {
-        onView(withId(R.id.loadingProgress))
-            .check(matches(withEffectiveVisibility(Visibility.GONE)))
-
-        onView(withId(R.id.refreshButton)).perform(click())
+    fun progressBarHidesAfterTestCompletes() {
+        onView(withId(R.id.runTestButton)).perform(click())
 
         Thread.sleep(1000)
 
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        Thread.sleep(3000)
+        Thread.sleep(5000)
 
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))

--- a/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
+++ b/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
@@ -1,0 +1,46 @@
+package com.example.routermanager
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+
+class NetworkSpeedTester(private val client: OkHttpClient = OkHttpClient()) {
+    suspend fun downloadSpeed(url: String, onProgress: (Int) -> Unit): Double =
+        withContext(Dispatchers.IO) {
+            val request = Request.Builder().url(url).build()
+            client.newCall(request).execute().use { response ->
+                val body = response.body ?: return@withContext 0.0
+                val length = body.contentLength()
+                val input = body.byteStream()
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var bytesRead = 0L
+                val start = System.nanoTime()
+                var read: Int
+                while (input.read(buffer).also { read = it } != -1) {
+                    bytesRead += read
+                    if (length > 0) {
+                        val percent = (bytesRead * 100 / length).toInt()
+                        onProgress(percent)
+                    }
+                }
+                val time = (System.nanoTime() - start) / 1_000_000_000.0
+                if (time == 0.0) 0.0 else (bytesRead * 8 / 1_000_000.0) / time
+            }
+        }
+
+    suspend fun uploadSpeed(url: String, file: File): Double =
+        withContext(Dispatchers.IO) {
+            val requestBody: RequestBody = file.asRequestBody("application/octet-stream".toMediaType())
+            val request = Request.Builder().url(url).post(requestBody).build()
+            val bytes = file.length()
+            val start = System.nanoTime()
+            client.newCall(request).execute().use { }
+            val time = (System.nanoTime() - start) / 1_000_000_000.0
+            if (time == 0.0) 0.0 else (bytes * 8 / 1_000_000.0) / time
+        }
+}

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -1,87 +1,58 @@
 package com.example.routermanager
 
-import android.annotation.SuppressLint
-import android.os.Bundle
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceError
-import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-import androidx.appcompat.app.AppCompatActivity
 import android.content.Intent
-import android.webkit.WebSettings
-import android.webkit.CookieManager
-import androidx.core.content.edit
+import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
-import android.graphics.Bitmap
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import kotlinx.coroutines.launch
 
 class SpeedTestActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
+    private lateinit var downloadText: TextView
+    private val tester = NetworkSpeedTester()
 
-    private inner class SpeedTestWebViewClient : WebViewClient() {
-        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-            super.onPageStarted(view, url, favicon)
-            progressBar.visibility = View.VISIBLE
-        }
-
-        override fun onPageFinished(view: WebView?, url: String?) {
-            super.onPageFinished(view, url)
-            progressBar.visibility = View.GONE
-        }
-
-        override fun onReceivedError(
-            view: WebView,
-            request: WebResourceRequest,
-            error: WebResourceError
-        ) {
-            super.onReceivedError(view, request, error)
-            if (request.isForMainFrame) {
-                progressBar.visibility = View.GONE
-            }
-        }
-    }
-    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_speed_test)
 
-        val webView: WebView = findViewById(R.id.speedTestWebView)
         progressBar = findViewById(R.id.loadingProgress)
+        downloadText = findViewById(R.id.downloadText)
+        val runButton: FloatingActionButton = findViewById(R.id.runTestButton)
         val backButton: FloatingActionButton = findViewById(R.id.backButton)
-        val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
         val buttonContainer: View = findViewById(R.id.buttonContainer)
         val toggleFab: FloatingActionButton = findViewById(R.id.toggleFab)
 
-        webView.webViewClient = SpeedTestWebViewClient()
-
-        webView.settings.apply {
-            javaScriptEnabled = true
-            domStorageEnabled = true
-            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-        }
-        CookieManager.getInstance().setAcceptCookie(true)
-        webView.loadUrl(/* url = */ "https://www.speedtest.net/")
-
-        backButton.setOnClickListener {
-            finish()
-        }
-        refreshButton.setOnClickListener {
-            webView.url?.let { currentUrl ->
-                webView.loadUrl(
-                    currentUrl
-                )
-            }
-        }
-        toggleFab.setOnClickListener {
-            toggleButtonContainer(buttonContainer, toggleFab)
-        }
+        runButton.setOnClickListener { startTest() }
+        backButton.setOnClickListener { finish() }
+        toggleFab.setOnClickListener { toggleButtonContainer(buttonContainer, toggleFab) }
         offButton.setOnClickListener {
             getSharedPreferences("settings", MODE_PRIVATE).edit { clear() }
             startActivity(Intent(this, SetupActivity::class.java))
             finish()
         }
+    }
+
+    private fun startTest() {
+        progressBar.visibility = View.VISIBLE
+        progressBar.progress = 0
+        downloadText.text = getString(R.string.loading)
+        lifecycleScope.launch {
+            val mbps = tester.downloadSpeed(TEST_FILE_URL) { percent ->
+                progressBar.progress = percent
+            }
+            progressBar.visibility = View.GONE
+            downloadText.text = getString(R.string.download_speed_format, mbps)
+        }
+    }
+
+    companion object {
+        private const val TEST_FILE_URL = "https://speed.hetzner.de/100MB.bin"
     }
 }

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -5,25 +5,23 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <WebView
-        android:id="@+id/speedTestWebView"
+    <ProgressBar
+        android:id="@+id/loadingProgress"
+        style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:max="100"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <ProgressBar
-        android:id="@+id/loadingProgress"
-        style="?android:attr/progressBarStyleLarge"
+    <TextView
+        android:id="@+id/downloadText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:indeterminate="true"
-        android:contentDescription="@string/loading"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="@string/download_speed_format"
+        app:layout_constraintTop_toBottomOf="@id/loadingProgress"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -49,11 +47,11 @@
             app:srcCompat="@android:drawable/ic_menu_revert" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/refreshButton"
+            android:id="@+id/runTestButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
-            android:contentDescription="@string/action_refresh"
+            android:contentDescription="@string/action_run_test"
             app:srcCompat="@drawable/ic_refresh" />
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
@@ -74,4 +72,5 @@
         app:srcCompat="@android:drawable/ic_menu_more"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="router_image_description">Router icon</string>
     <string name="action_refresh">Refresh</string>
     <string name="action_speed_test">Speed Test</string>
+    <string name="action_run_test">Run Test</string>
+    <string name="download_speed_format">Download: %.2f Mbps</string>
     <string name="action_access">Access</string>
     <string name="action_back">Back</string>
     <string name="action_power_off">Power Off</string>


### PR DESCRIPTION
## Summary
- swap SpeedTestActivity WebView for coroutine-based tester
- implement `NetworkSpeedTester` using OkHttp
- update UI layout with progress bar and test button
- validate new behaviour in SpeedTestActivityTest
- document new speed test feature

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a90cac37c8333ab4c58bf81ca46dc