### PR TITLE
Fix download progress callback thread

### DIFF
--- a/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
+++ b/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
@@ -25,7 +25,9 @@ class NetworkSpeedTester(private val client: OkHttpClient = OkHttpClient()) {
                     bytesRead += read
                     if (length > 0) {
                         val percent = (bytesRead * 100 / length).toInt()
-                        onProgress(percent)
+                        withContext(Dispatchers.Main) {
+                            onProgress(percent)
+                        }
                     }
                 }
                 val time = (System.nanoTime() - start) / 1_000_000_000.0


### PR DESCRIPTION
## Summary
- run download progress callbacks on `Dispatchers.Main`

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a934159008333b6d0188b0e03f2fe