### PR TITLE
Handle speed test exceptions

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -8,6 +8,8 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.example.routermanager.SpeedTester
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -59,6 +61,29 @@ class SpeedTestActivityTest {
 
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
+
+    @Test
+    fun progressBarHidesAndErrorShownOnFailure() {
+        activityRule.scenario.onActivity { activity ->
+            activity.tester = object : SpeedTester {
+                override suspend fun downloadSpeed(
+                    url: String,
+                    onProgress: (Int) -> Unit,
+                ): Double {
+                    throw RuntimeException("boom")
+                }
+            }
+        }
+
+        onView(withId(R.id.runTestButton)).perform(click())
+
+        Thread.sleep(1000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+        onView(withId(R.id.downloadText))
+            .check(matches(withText(R.string.speed_test_failed)))
     }
 }
 

--- a/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
+++ b/app/src/main/java/com/example/routermanager/NetworkSpeedTester.kt
@@ -9,8 +9,8 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 
-class NetworkSpeedTester(private val client: OkHttpClient = OkHttpClient()) {
-    suspend fun downloadSpeed(url: String, onProgress: (Int) -> Unit): Double =
+class NetworkSpeedTester(private val client: OkHttpClient = OkHttpClient()) : SpeedTester {
+    override suspend fun downloadSpeed(url: String, onProgress: (Int) -> Unit): Double =
         withContext(Dispatchers.IO) {
             val request = Request.Builder().url(url).build()
             client.newCall(request).execute().use { response ->

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.View
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import androidx.lifecycle.lifecycleScope
@@ -15,7 +17,7 @@ import kotlinx.coroutines.launch
 class SpeedTestActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var downloadText: TextView
-    private val tester = NetworkSpeedTester()
+    internal var tester: SpeedTester = NetworkSpeedTester()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,11 +46,22 @@ class SpeedTestActivity : AppCompatActivity() {
         progressBar.progress = 0
         downloadText.text = getString(R.string.loading)
         lifecycleScope.launch {
-            val mbps = tester.downloadSpeed(TEST_FILE_URL) { percent ->
-                progressBar.progress = percent
+            try {
+                val mbps = tester.downloadSpeed(TEST_FILE_URL) { percent ->
+                    progressBar.progress = percent
+                }
+                progressBar.visibility = View.GONE
+                downloadText.text = getString(R.string.download_speed_format, mbps)
+            } catch (e: Exception) {
+                Log.e("SpeedTestActivity", "Speed test failed", e)
+                progressBar.visibility = View.GONE
+                downloadText.text = getString(R.string.speed_test_failed)
+                Toast.makeText(
+                    this@SpeedTestActivity,
+                    R.string.speed_test_failed,
+                    Toast.LENGTH_LONG
+                ).show()
             }
-            progressBar.visibility = View.GONE
-            downloadText.text = getString(R.string.download_speed_format, mbps)
         }
     }
 

--- a/app/src/main/java/com/example/routermanager/SpeedTester.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTester.kt
@@ -1,0 +1,5 @@
+package com.example.routermanager
+
+interface SpeedTester {
+    suspend fun downloadSpeed(url: String, onProgress: (Int) -> Unit): Double
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="hint_router_url">Router URL</string>
     <string name="version_format">Version %1$s</string>
     <string name="loading">Loading...</string>
+    <string name="speed_test_failed">Speed test failed</string>
 </resources>


### PR DESCRIPTION
## Summary
- catch exceptions when running network speed test
- show a Toast and update the download text on failure
- allow injecting a `SpeedTester` for testing
- add tests for error handling during the speed test

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a93bccae08333adc54cd5dbf86adc