### PR TITLE
Revert speed test to WebView implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Not all routers come with official mobile apps. Most rely on outdated web portal
 - ✅ Loads the web interface in a secure WebView
 - ✅ "Off" button to reset stored IP
 - ✅ Simple and intuitive interface
-- ✅ Built-in network speed test
 
 ---
 
@@ -119,19 +118,7 @@ Ensure a device or emulator is connected.
 3. On first run, the app scans your local network and auto-detects your router’s IP.
 4. The router IP is saved for future launches.
 5. Tap **Access** to open the WebView.
-6. Open the menu and tap **Run Test** to measure your network speed.
-   The test downloads a small file from `https://speed.hetzner.de/10MB.bin`.
-7. Use the **Off** button to reset the saved address and re-trigger detection.
-
----
-
-## 📚 Speed Test Library
-
-The built-in speed test uses the open source [speed-test-lib](https://github.com/bertrandmartel/speed-test-lib) library.
-It is included via [JitPack](https://jitpack.io) and provides the `SpeedTestSocket` class whose callbacks report progress,
-completion and errors. RouterManager hooks into these events to update the UI and display the measured download speed.
-
-The library is released under the Apache 2.0 license.
+6. Use the **Off** button to reset the saved address and re-trigger detection.
 
 ---
 
@@ -160,7 +147,6 @@ No personal data is collected or transmitted.
 
 This project is licensed under the [Personal Use License](LICENSE).
 You are free to use and modify the code for non-commercial purposes with proper attribution.
-The included `speed-test-lib` dependency is licensed under Apache 2.0.
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,6 @@ android {
         targetSdk 35
         versionCode count
         versionName "v${major}.${minor.toString().padLeft(2, '0')}.${patch.toString().padLeft(2, '0')}-${gitSha.getOrElse('dev')}"
-        buildConfigField "String", "TEST_FILE_URL", '"https://speed.hetzner.de/10MB.bin"'
     }
 
     buildTypes {
@@ -56,8 +55,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'com.github.bertrandmartel:speed-test-lib:2.1.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -1,0 +1,67 @@
+package com.example.routermanager
+
+import android.webkit.WebView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SpeedTestActivityTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(SpeedTestActivity::class.java)
+
+    @Test
+    fun webViewLoadsExpectedUrl() {
+        onView(withId(R.id.speedTestWebView)).check { view, noViewFoundException ->
+            if (noViewFoundException != null) throw noViewFoundException
+            val webView = view as WebView
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            assertEquals("https://www.speedtest.net/", webView.url)
+        }
+    }
+
+    @Test
+    fun toggleFabTogglesButtonsVisibility() {
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.toggleFab)).perform(click())
+
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        onView(withId(R.id.toggleFab)).perform(click())
+
+        onView(withId(R.id.buttonContainer))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
+
+    @Test
+    fun progressBarTogglesOnPageLoad() {
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+
+        onView(withId(R.id.refreshButton)).perform(click())
+
+        Thread.sleep(1000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        Thread.sleep(3000)
+
+        onView(withId(R.id.loadingProgress))
+            .check(matches(withEffectiveVisibility(Visibility.GONE)))
+    }
+}
+

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -1,84 +1,87 @@
 package com.example.routermanager
 
-import android.content.Intent
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceError
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
+import android.webkit.WebSettings
+import android.webkit.CookieManager
+import androidx.core.content.edit
 import android.view.View
 import android.widget.ProgressBar
-import android.widget.TextView
-import android.widget.Toast
-import android.util.Log
-import com.example.routermanager.BuildConfig
-import fr.bmartel.speedtest.SpeedTestReport
-import fr.bmartel.speedtest.SpeedTestSocket
-import fr.bmartel.speedtest.inter.ISpeedTestListener
-import fr.bmartel.speedtest.model.SpeedTestError
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-import com.google.android.material.floatingactionbutton.FloatingActionButton
+import android.graphics.Bitmap
 
 class SpeedTestActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
-    private lateinit var downloadText: TextView
-    private val socket = SpeedTestSocket()
 
+    private inner class SpeedTestWebViewClient : WebViewClient() {
+        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+            super.onPageStarted(view, url, favicon)
+            progressBar.visibility = View.VISIBLE
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            super.onPageFinished(view, url)
+            progressBar.visibility = View.GONE
+        }
+
+        override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError
+        ) {
+            super.onReceivedError(view, request, error)
+            if (request.isForMainFrame) {
+                progressBar.visibility = View.GONE
+            }
+        }
+    }
+    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_speed_test)
 
+        val webView: WebView = findViewById(R.id.speedTestWebView)
         progressBar = findViewById(R.id.loadingProgress)
-        downloadText = findViewById(R.id.downloadText)
-        val runButton: FloatingActionButton = findViewById(R.id.runTestButton)
         val backButton: FloatingActionButton = findViewById(R.id.backButton)
+        val refreshButton: FloatingActionButton = findViewById(R.id.refreshButton)
         val offButton: ExtendedFloatingActionButton = findViewById(R.id.offButton)
         val buttonContainer: View = findViewById(R.id.buttonContainer)
         val toggleFab: FloatingActionButton = findViewById(R.id.toggleFab)
 
-        runButton.setOnClickListener { startTest() }
-        backButton.setOnClickListener { finish() }
-        toggleFab.setOnClickListener { toggleButtonContainer(buttonContainer, toggleFab) }
+        webView.webViewClient = SpeedTestWebViewClient()
+
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        }
+        CookieManager.getInstance().setAcceptCookie(true)
+        webView.loadUrl(/* url = */ "https://www.speedtest.net/")
+
+        backButton.setOnClickListener {
+            finish()
+        }
+        refreshButton.setOnClickListener {
+            webView.url?.let { currentUrl ->
+                webView.loadUrl(
+                    currentUrl
+                )
+            }
+        }
+        toggleFab.setOnClickListener {
+            toggleButtonContainer(buttonContainer, toggleFab)
+        }
         offButton.setOnClickListener {
             getSharedPreferences("settings", MODE_PRIVATE).edit { clear() }
             startActivity(Intent(this, SetupActivity::class.java))
             finish()
         }
-    }
-
-    private fun startTest() {
-        progressBar.visibility = View.VISIBLE
-        progressBar.progress = 0
-        downloadText.text = getString(R.string.loading)
-
-        val listener = object : ISpeedTestListener {
-            override fun onProgress(percent: Float, report: SpeedTestReport) {
-                runOnUiThread { progressBar.progress = percent.toInt() }
-            }
-
-            override fun onCompletion(report: SpeedTestReport) {
-                socket.removeSpeedTestListener(this)
-                runOnUiThread {
-                    progressBar.visibility = View.GONE
-                    val mbps = report.transferRateBit.toDouble() / 1_000_000
-                    downloadText.text = getString(R.string.download_speed_format, mbps)
-                }
-            }
-
-            override fun onError(speedTestError: SpeedTestError, errorMessage: String) {
-                socket.removeSpeedTestListener(this)
-                runOnUiThread {
-                    Log.e("SpeedTestActivity", "Speed test failed: $errorMessage")
-                    progressBar.visibility = View.GONE
-                    downloadText.text = getString(R.string.speed_test_failed)
-                    Toast.makeText(this@SpeedTestActivity, R.string.speed_test_failed, Toast.LENGTH_LONG).show()
-                }
-            }
-        }
-
-        socket.addSpeedTestListener(listener)
-        socket.startDownload(TEST_FILE_URL)
-    }
-
-    companion object {
-        private const val TEST_FILE_URL = BuildConfig.TEST_FILE_URL
     }
 }

--- a/app/src/main/res/layout/activity_speed_test.xml
+++ b/app/src/main/res/layout/activity_speed_test.xml
@@ -5,23 +5,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ProgressBar
-        android:id="@+id/loadingProgress"
-        style="?android:attr/progressBarStyleHorizontal"
+    <WebView
+        android:id="@+id/speedTestWebView"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:max="100"
+        android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <TextView
-        android:id="@+id/downloadText"
+    <ProgressBar
+        android:id="@+id/loadingProgress"
+        style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/download_speed_format"
-        app:layout_constraintTop_toBottomOf="@id/loadingProgress"
+        android:visibility="gone"
+        android:indeterminate="true"
+        android:contentDescription="@string/loading"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -47,11 +49,11 @@
             app:srcCompat="@android:drawable/ic_menu_revert" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/runTestButton"
+            android:id="@+id/refreshButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
-            android:contentDescription="@string/action_run_test"
+            android:contentDescription="@string/action_refresh"
             app:srcCompat="@drawable/ic_refresh" />
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
@@ -72,5 +74,4 @@
         app:srcCompat="@android:drawable/ic_menu_more"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,8 +4,6 @@
     <string name="router_image_description">Router icon</string>
     <string name="action_refresh">Refresh</string>
     <string name="action_speed_test">Speed Test</string>
-    <string name="action_run_test">Run Test</string>
-    <string name="download_speed_format">Download: %.2f Mbps</string>
     <string name="action_access">Access</string>
     <string name="action_back">Back</string>
     <string name="action_power_off">Power Off</string>
@@ -21,5 +19,4 @@
     <string name="hint_router_url">Router URL</string>
     <string name="version_format">Version %1$s</string>
     <string name="loading">Loading...</string>
-    <string name="speed_test_failed">Speed test failed</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.10.1'
@@ -15,6 +14,5 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
## Summary
- roll back speed test feature to earlier WebView-based version
- remove JitPack repository and speed test library dependency
- restore SpeedTestActivity test
- update README and strings accordingly

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a983a2da08333926e569c2d3b4eb4