### PR TITLE
Refactor port check into NetworkUtils

### DIFF
--- a/app/src/main/java/com/example/routermanager/NetworkUtils.kt
+++ b/app/src/main/java/com/example/routermanager/NetworkUtils.kt
@@ -1,0 +1,17 @@
+package com.example.routermanager
+
+import java.net.InetSocketAddress
+import java.net.Socket
+
+object NetworkUtils {
+    fun isPortOpen(host: String, port: Int, timeoutMs: Int): Boolean {
+        return try {
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress(host, port), timeoutMs)
+            }
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -3,8 +3,6 @@ package com.example.routermanager
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import java.net.InetSocketAddress
-import java.net.Socket
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -71,8 +69,8 @@ class SetupActivity : AppCompatActivity() {
             val scheme = withContext(Dispatchers.IO) {
                 address?.let {
                     when {
-                        isPortOpen(it, 80, 200) -> "http://"
-                        isPortOpen(it, 443, 200) -> "https://"
+                        NetworkUtils.isPortOpen(it, 80, 200) -> "http://"
+                        NetworkUtils.isPortOpen(it, 443, 200) -> "https://"
                         else -> "http://"
                     }
                 }
@@ -102,13 +100,3 @@ class SetupActivity : AppCompatActivity() {
     }
 }
 
-private fun isPortOpen(host: String, port: Int, timeoutMs: Int): Boolean {
-    return try {
-        Socket().use { socket ->
-            socket.connect(InetSocketAddress(host, port), timeoutMs)
-        }
-        true
-    } catch (_: Exception) {
-        false
-    }
-}


### PR DESCRIPTION
## Summary
- add `NetworkUtils` helper with `isPortOpen`
- use `NetworkUtils.isPortOpen` from `SetupActivity`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f3eb9d0833386674ff3728aeb3c