### PR TITLE
Introduce SharedPreferences helper

### DIFF
--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -122,7 +122,7 @@ class MainActivity : AppCompatActivity() {
     @SuppressLint("SetJavaScriptEnabled", "ObsoleteSdkInt")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        prefs = settingsPrefs
         sslTrusted = savedInstanceState?.getBoolean(PrefsKeys.KEY_SSL_TRUSTED)
             ?: prefs.getBoolean(PrefsKeys.KEY_SSL_TRUSTED, false)
         val routerUrl = prefs.getString(PrefsKeys.KEY_ROUTER_URL, "")

--- a/app/src/main/java/com/example/routermanager/PreferencesHelper.kt
+++ b/app/src/main/java/com/example/routermanager/PreferencesHelper.kt
@@ -1,0 +1,7 @@
+package com.example.routermanager
+
+import android.content.Context
+import android.content.SharedPreferences
+
+val Context.settingsPrefs: SharedPreferences
+    get() = getSharedPreferences("settings", Context.MODE_PRIVATE)

--- a/app/src/main/java/com/example/routermanager/SetupActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SetupActivity.kt
@@ -27,7 +27,7 @@ class SetupActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val forceSetup = intent.getBooleanExtra(Constants.EXTRA_FORCE_SETUP, false)
-        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        val prefs = settingsPrefs
         if (!forceSetup && prefs.contains(PrefsKeys.KEY_ROUTER_URL)) {
             startActivity(Intent(this, MainActivity::class.java))
             finish()

--- a/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
+++ b/app/src/main/java/com/example/routermanager/SpeedTestActivity.kt
@@ -79,7 +79,7 @@ class SpeedTestActivity : AppCompatActivity() {
             toggleButtonContainer(buttonContainer, toggleFab)
         }
         offButton.setOnClickListener {
-            getSharedPreferences("settings", MODE_PRIVATE).edit { clear() }
+            settingsPrefs.edit { clear() }
             startActivity(Intent(this, SetupActivity::class.java))
             finish()
         }


### PR DESCRIPTION
## Summary
- add PreferencesHelper for simplified access to persistent app settings
- use the new helper in activities

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa04719e48333b7da26c4302ce984