### PR TITLE
Restrict cleartext traffic

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true" />
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- Permit cleartext only for local router addresses -->
+        <domain includeSubdomains="true">192.168.0.0/16</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- disable cleartext traffic globally
- permit local router IPs via domain-config

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa24b1cf4833386f5755d30983a9c