### PR TITLE
Improve mixed content handling

### DIFF
--- a/app/src/main/java/com/example/routermanager/BaseWebViewActivity.kt
+++ b/app/src/main/java/com/example/routermanager/BaseWebViewActivity.kt
@@ -13,7 +13,7 @@ open class BaseWebViewActivity : AppCompatActivity() {
         webView.settings.apply {
             javaScriptEnabled = true
             domStorageEnabled = true
-            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+            mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         }
         CookieManager.getInstance().setAcceptCookie(true)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/com/example/routermanager/MainActivity.kt
+++ b/app/src/main/java/com/example/routermanager/MainActivity.kt
@@ -15,6 +15,7 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.webkit.WebSettings
 import android.widget.ProgressBar
 import com.example.routermanager.BaseWebViewActivity
 import androidx.core.content.edit
@@ -166,6 +167,10 @@ class MainActivity : BaseWebViewActivity() {
             }
         }
         applyCommonWebViewSettings(webView)
+        if (routerUrl.startsWith("https://")) {
+            webView.settings.mixedContentMode =
+                WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        }
 
         if (routerUrl.startsWith("https://") && !sslTrusted) {
             AlertDialog.Builder(this)


### PR DESCRIPTION
## Summary
- prefer `MIXED_CONTENT_COMPATIBILITY_MODE` for WebView
- tighten to `MIXED_CONTENT_NEVER_ALLOW` when loading an HTTPS router URL

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa33d96788333a998922101767259