### PR TITLE
Use IdlingResource in tests

### DIFF
--- a/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/MainActivityTest.kt
@@ -7,6 +7,9 @@ import android.content.Context
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.IdlingRegistry
+import android.view.View
+import com.example.routermanager.ViewVisibilityIdlingResource
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
@@ -65,14 +68,24 @@ class MainActivityTest {
 
         onView(withId(R.id.refreshButton)).perform(click())
 
-        Thread.sleep(1000)
-
+        val visibleResource = ViewVisibilityIdlingResource(
+            activityRule.scenario,
+            R.id.loadingProgress,
+            View.VISIBLE
+        )
+        IdlingRegistry.getInstance().register(visibleResource)
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        IdlingRegistry.getInstance().unregister(visibleResource)
 
-        Thread.sleep(3000)
-
+        val goneResource = ViewVisibilityIdlingResource(
+            activityRule.scenario,
+            R.id.loadingProgress,
+            View.GONE
+        )
+        IdlingRegistry.getInstance().register(goneResource)
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
+        IdlingRegistry.getInstance().unregister(goneResource)
     }
 }

--- a/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/SpeedTestActivityTest.kt
@@ -6,6 +6,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.IdlingRegistry
+import android.view.View
+import com.example.routermanager.ViewVisibilityIdlingResource
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
@@ -53,15 +56,25 @@ class SpeedTestActivityTest {
 
         onView(withId(R.id.refreshButton)).perform(click())
 
-        Thread.sleep(1000)
-
+        val visibleResource = ViewVisibilityIdlingResource(
+            activityRule.scenario,
+            R.id.loadingProgress,
+            View.VISIBLE
+        )
+        IdlingRegistry.getInstance().register(visibleResource)
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        IdlingRegistry.getInstance().unregister(visibleResource)
 
-        Thread.sleep(3000)
-
+        val goneResource = ViewVisibilityIdlingResource(
+            activityRule.scenario,
+            R.id.loadingProgress,
+            View.GONE
+        )
+        IdlingRegistry.getInstance().register(goneResource)
         onView(withId(R.id.loadingProgress))
             .check(matches(withEffectiveVisibility(Visibility.GONE)))
+        IdlingRegistry.getInstance().unregister(goneResource)
     }
 }
 

--- a/app/src/androidTest/java/com/example/routermanager/ViewVisibilityIdlingResource.kt
+++ b/app/src/androidTest/java/com/example/routermanager/ViewVisibilityIdlingResource.kt
@@ -1,0 +1,33 @@
+package com.example.routermanager
+
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.IdlingResource
+
+class ViewVisibilityIdlingResource(
+    private val scenario: ActivityScenario<*>,
+    @IdRes private val viewId: Int,
+    private val expectedVisibility: Int
+) : IdlingResource {
+    @Volatile
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    override fun getName(): String = "ViewVisibilityIdlingResource:$viewId:$expectedVisibility"
+
+    override fun isIdleNow(): Boolean {
+        var idle = false
+        scenario.onActivity { activity ->
+            val view = activity.findViewById<View>(viewId)
+            idle = view.visibility == expectedVisibility
+        }
+        if (idle) {
+            callback?.onTransitionToIdle()
+        }
+        return idle
+    }
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+        this.callback = callback
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `ViewVisibilityIdlingResource`
- wait on progress bar visibility instead of using sleeps in `MainActivityTest` and `SpeedTestActivityTest`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa4388490833386389514c4adc17e