### PR TITLE
Add WebView instrumentation test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
         targetSdk 35
         versionCode count
         versionName "v${major}.${minor.toString().padLeft(2, '0')}.${patch.toString().padLeft(2, '0')}-${gitSha.getOrElse('dev')}"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -55,6 +56,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/com/example/routermanager/WebViewSavedUrlTest.kt
+++ b/app/src/androidTest/java/com/example/routermanager/WebViewSavedUrlTest.kt
@@ -1,0 +1,32 @@
+package com.example.routermanager
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebViewSavedUrlTest {
+
+    @Test
+    fun webViewLoadsSavedRouterUrl() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+        prefs.edit().putString(PrefsKeys.KEY_ROUTER_URL, "http://192.168.1.1/").commit()
+
+        ActivityScenario.launch(MainActivity::class.java).use {
+            onView(withId(R.id.routerWebView)).check { view, noViewFoundException ->
+                if (noViewFoundException != null) throw noViewFoundException
+                val webView = view as WebView
+                InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+                assertEquals("http://192.168.1.1/", webView.url)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple instrumentation test verifying that MainActivity loads the saved router URL
- specify AndroidJUnitRunner in app module and include the runner dependency

## Testing
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa8c996083339448ba74c1a20227