### PR TITLE
Add Android SDK path setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Before building or running the project, ensure the following are installed:
 - **JDK 17** (required for Android Gradle Plugin 8.x)
 - **Git** (for automatic versioning - fallback supported if missing)
 
+### Configure Android SDK path
+
+Create a `local.properties` file in the project root containing:
+
+```ini
+sdk.dir=/path/to/Android/Sdk
+```
+
+Alternatively, set the `ANDROID_SDK_ROOT` environment variable.
+
+`local.properties` is already listed in `.gitignore` and should not be committed.
+
 ---
 
 ## 🛠️ Building the App


### PR DESCRIPTION
## Summary
- document how to set the Android SDK path using `local.properties` or `ANDROID_SDK_ROOT`
- remind contributors not to commit `local.properties`

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ab03dfc848333bfc6f2dcfd5ead97