### PR TITLE
Add Arilia APT attribution framework

### DIFF
--- a/arilia/README.md
+++ b/arilia/README.md
@@ -1,0 +1,16 @@
+# Arilia APT Attribution Framework
+
+## Components:
+- `core/`: Modular components for semantic extraction, feature normalization, attribution
+- `notebooks/`: Development notebook
+- `streamlit_app/`: Analyst-friendly frontend
+
+## Usage:
+Run the notebook or launch Streamlit:
+
+```bash
+streamlit run streamlit_app/app.py
+```
+
+## Notes:
+Uses Ollama for secure local inference. Replace mock logic with actual model integration.

--- a/arilia/core/evaluator.py
+++ b/arilia/core/evaluator.py
@@ -1,0 +1,7 @@
+"""Evaluation utilities."""
+from sklearn.metrics import classification_report
+
+
+def evaluate(true_labels, predicted_labels):
+    """Print classification report for predictions."""
+    print(classification_report(true_labels, predicted_labels))

--- a/arilia/core/feature_normalizer.py
+++ b/arilia/core/feature_normalizer.py
@@ -1,0 +1,12 @@
+"""Feature normalization utilities."""
+from typing import Dict
+
+
+def normalize_features(data: Dict[str, list]) -> Dict[str, int]:
+    """Convert extracted behaviour data into structured features."""
+    features = {f"ttp_{ttp}": 1 for ttp in data.get("ttps", [])}
+    features.update({
+        "uses_PowerShell": int("PowerShell" in data.get("tools", [])),
+        "sector_telecom": int(data.get("sector") == "telecom"),
+    })
+    return features

--- a/arilia/core/ollama_runner.py
+++ b/arilia/core/ollama_runner.py
@@ -1,0 +1,24 @@
+"""Ollama runner for behaviour extraction."""
+from typing import Dict
+
+
+def extract_behaviours(text: str) -> Dict[str, list]:
+    """Use Ollama CLI or API to extract behaviours from raw text.
+
+    Parameters
+    ----------
+    text: str
+        Threat report text to analyze.
+
+    Returns
+    -------
+    dict
+        Dictionary containing extracted behaviours.
+    """
+    # TODO: Replace with actual Ollama integration
+    return {
+        "ttps": ["T1059", "T1075"],
+        "tools": ["PowerShell"],
+        "malware": ["PlugX"],
+        "sector": "telecom",
+    }

--- a/arilia/core/rst_engine.py
+++ b/arilia/core/rst_engine.py
@@ -1,0 +1,17 @@
+"""Mock Rough Set Theory engine for attribution."""
+from typing import Dict
+
+
+def classify_with_rough_set(features: Dict[str, int]) -> Dict[str, object]:
+    """Classify using basic rough set-like logic (mocked)."""
+    if features.get("ttp_T1059") and features.get("sector_telecom"):
+        return {
+            "group": "APT10",
+            "confidence": 0.92,
+            "explanation": "Detected PowerShell usage in telecom sector with PlugX.",
+        }
+    return {
+        "group": "Unknown",
+        "confidence": 0.5,
+        "explanation": "Insufficient features for confident attribution.",
+    }

--- a/arilia/data/apt_samples/sample_report.txt
+++ b/arilia/data/apt_samples/sample_report.txt
@@ -1,0 +1,1 @@
+Sample APT threat report text about PowerShell usage with PlugX in telecom sector.

--- a/arilia/notebooks/analysis_pipeline.ipynb
+++ b/arilia/notebooks/analysis_pipeline.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Arilia Analysis Pipeline\n",
+    "Load text, extract behaviours, normalize features, classify, and evaluate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from arilia.core.ollama_runner import extract_behaviours\n",
+    "from arilia.core.feature_normalizer import normalize_features\n",
+    "from arilia.core.rst_engine import classify_with_rough_set\n",
+    "from arilia.core.evaluator import evaluate\n",
+    "\n",
+    "text = Path('../data/apt_samples/sample_report.txt').read_text()\n",
+    "data = extract_behaviours(text)\n",
+    "features = normalize_features(data)\n",
+    "result = classify_with_rough_set(features)\n",
+    "print(result)\n",
+    "# Mock ground truth label\n",
+    "y_true = ['APT10']\n",
+    "y_pred = [result['group']]\n",
+    "evaluate(y_true, y_pred)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/arilia/requirements.txt
+++ b/arilia/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+scikit-learn
+pandas
+matplotlib

--- a/arilia/streamlit_app/app.py
+++ b/arilia/streamlit_app/app.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from arilia.core.ollama_runner import extract_behaviours
+from arilia.core.feature_normalizer import normalize_features
+from arilia.core.rst_engine import classify_with_rough_set
+
+st.title("APT Attribution Engine")
+
+uploaded_file = st.file_uploader("Upload a threat report", type="txt")
+if uploaded_file:
+    text = uploaded_file.read().decode("utf-8")
+    st.subheader("\U0001F4C4 Report Text")
+    st.text(text)
+
+    st.subheader("\U0001F9E0 Behaviour Extraction")
+    data = extract_behaviours(text)
+    st.json(data)
+
+    st.subheader("\U0001F522 Normalized Features")
+    features = normalize_features(data)
+    st.json(features)
+
+    st.subheader("\U0001F3AF Attribution Result")
+    result = classify_with_rough_set(features)
+    st.write(f"**Group:** {result['group']}")
+    st.write(f"**Confidence:** {result['confidence']}")
+    st.write(f"**Explanation:** {result['explanation']}")


### PR DESCRIPTION
## Summary
- add new Arilia module with APT attribution functionality
- include core modules for behaviour extraction, feature normalization, and rough set classification
- provide evaluation util, notebook, and Streamlit frontend
- add requirements and documentation

## Testing
- `python -m py_compile arilia/core/*.py`
- ran sample extraction/classification script

------
https://chatgpt.com/codex/tasks/task_e_68882b2c44a4833394e603c1b4df532f